### PR TITLE
Fix readthedocs builds

### DIFF
--- a/docs/_source/conf.py
+++ b/docs/_source/conf.py
@@ -4,9 +4,11 @@
 #
 
 project = u'EveryVoter'
+author = u'Nick Catalano'
 
 extensions = [
     'sphinxcontrib.images',
+    "sphinx_rtd_theme",
 ]
 
 templates_path = ['_templates']

--- a/docs/_source/conf.py
+++ b/docs/_source/conf.py
@@ -24,7 +24,8 @@ html_theme_options = {
 html_static_path = ['_static']
 htmlhelp_basename = 'EveryVoterdoc'
 latex_documents = [
-    (master_doc, 'EveryVoter.tex', u'EveryVoter Documentation', 'manual'),
+    (master_doc, 'EveryVoter.tex', u'EveryVoter Documentation',
+     u'everyvoter', 'manual'),
 ]
 man_pages = [
     (master_doc, 'everyvoter', u'EveryVoter Documentation',

--- a/docs/doc-requirements.txt
+++ b/docs/doc-requirements.txt
@@ -1,4 +1,4 @@
-sphinx
-sphinx_rtd_theme
-sphinx-autobuild
+sphinx==2.2.1
+sphinx_rtd_theme==0.4.3
+sphinx-autobuild==0.7.1
 -e git+https://github.com/t-b/sphinxcontrib-images.git@c76b9c25efb249f9c5054adbb436455095c6d2f7#egg=sphinxcontrib-images

--- a/docs/doc-requirements.txt
+++ b/docs/doc-requirements.txt
@@ -1,4 +1,4 @@
 sphinx
 sphinx_rtd_theme
 sphinx-autobuild
-sphinxcontrib-images
+-e git+https://github.com/t-b/sphinxcontrib-images.git@c76b9c25efb249f9c5054adbb436455095c6d2f7#egg=sphinxcontrib-images


### PR DESCRIPTION
readthedocs isn't building our documentation because the documentation was built for an older version of sphinx running on python2.7, and we don't live in that world anymore.

This hard-codes the versions of sphinx we need.

Once https://github.com/spinus/sphinxcontrib-images/pull/56 is sorted out we can remove the git requirement step.